### PR TITLE
fix: remove extra fi

### DIFF
--- a/copr
+++ b/copr
@@ -82,7 +82,6 @@ if [[ "$1" == "enable" ]]; then
             esac
         done
     fi
-fi
 
 # remove the named repo
 elif [[ "$1" == "remove" ]]; then


### PR DESCRIPTION
Getting an error when running `copr list` downstream. Looks like one of the if statements has an extra fi so it's not getting to the elif statements

This is the error message

```bash
/usr/bin/copr: line 88: syntax error near unexpected token `elif'
/usr/bin/copr: line 88: `elif [[ "$1" == "remove" ]]; then'
```

This change seems to fix the issue.