### PR TITLE
fix: change invalid elif to if

### DIFF
--- a/copr
+++ b/copr
@@ -72,11 +72,11 @@ if [[ "$1" == "enable" ]]; then
         while true; do
             read -p "$question" yn
             case $yn in
-                [Yy]* ) 
+                [Yy]* )
                     echo "$author/$reponame -> $releasever"
                     curl -fsSL "https://copr.fedorainfracloud.org/coprs/$author/$reponame/repo/fedora-$releasever/$author-$reponame-fedora-.repo" | pkexec tee "$repofile" && break
                     ;;
-                * ) 
+                * )
                     echo "Unknown option, exiting." && break
                     ;;
             esac
@@ -85,7 +85,7 @@ if [[ "$1" == "enable" ]]; then
 fi
 
 # remove the named repo
-elif [[ "$1" == "remove" ]]; then
+if [[ "$1" == "remove" ]]; then
   # backup the repofile and change owner to user
   mkdir ~/COPR
 


### PR DESCRIPTION
There is an elif instead of an if, causing a runtime error.

This was tested on the latest version of the copr command repo.

OS: Bazzite

Error messge:

```
./copr enable shadowblip/InputPlumber 
...
Do you really want to enable copr.fedorainfracloud.org/shadowblip/InputPlumber? [y/N]:y
...
./copr: line 88: syntax error near unexpected token `elif'
./copr: line 88: `elif [[ "$1" == "remove" ]]; then'
``