### PR TITLE
fixed unbound variables and added -p flag to mkdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install:
 ```
 curl https://raw.githubusercontent.com/boredsquirrel/COPR-command/main/copr -O ./copr
 run0 sh -c '
-  mkdir /var/usrlocal/bin
+  mkdir -p /var/usrlocal/bin
   mv ./copr /var/usrlocal/bin
   chown -R root:root /var/usrlocal/bin
   chcon -R system_u:object_r:bin_t:s0 /var/usrlocal/bin

--- a/copr
+++ b/copr
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # assign variables for author, reponame and releaseversion
-author="$(echo "$2" | cut -d '/' -f1)"
-reponame="$(echo "$2" | cut -d '/' -f2)"
+author="$(echo "${2:-}" | cut -d '/' -f1)"
+reponame="$(echo "${2:-}" | cut -d '/' -f2)"
 releasever="$(rpm -E %fedora)"
 repofile="/etc/yum.repos.d/_copr_$author-$reponame.repo"
 repofilebak="$HOME/COPR/_copr_$author-$reponame.repo"
@@ -89,7 +89,7 @@ move-repo () {
 
 # Main loop
 
-if [[ "$1" == "enable" ]]; then
+if [[ "${1:-}" == "enable" ]]; then
         while true; do
                 read -rp "$question" yn
                 case $yn in
@@ -114,13 +114,13 @@ if [[ "$1" == "enable" ]]; then
         done
 
 # disable a repo
-elif [[ "$1" == "disable" ]]; then
+elif [[ "${1:-}" == "disable" ]]; then
         sed 's/enabled=1/enabled=0/g' "$repofile" >/dev/null &&
                 echo "Repository "$author"/"$reponame" disabled." ||
                 echo "Already disabled or repo not found."
 
 # remove the named repo
-elif [[ "$1" == "remove" ]]; then
+elif [[ "${1:-}" == "remove" ]]; then
 
         if [[ -e "$repofile" ]]; then
                 move-repo
@@ -145,14 +145,14 @@ elif [[ "$1" == "remove" ]]; then
         fi
 
 # list all installed COPR repositories
-elif [[ "$1" == "list" ]]; then
+elif [[ "${1:-}" == "list" ]]; then
         find /etc/yum.repos.d/ -type f -name '_copr*' -exec basename {} \; | sed 's/_copr_//; s/\.repo$//'
 
 # search, this is just implemented through the browser (hey, pip does the same!)
-elif [[ "$1" == "search" ]]; then
+elif [[ "${1:-}" == "search" ]]; then
         xdg-open "https://copr.fedorainfracloud.org/coprs/fulltext/?fulltext=$2"
 
 # display the helptext
-elif [[ "$1" == "" || "$1" == "-h" || "$1" == "--h" || "$1" == "-help" || "$1" == "--help" || "$1" == "help" ]]; then
+elif [[ "${1:-}" == "" || "$1" == "-h" || "$1" == "--h" || "$1" == "-help" || "$1" == "--help" || "$1" == "help" ]]; then
         echo "$helptext"
 fi

--- a/copr
+++ b/copr
@@ -80,11 +80,12 @@ move-repo () {
         [ ! -d "$HOME/COPR" ] && mkdir -p "$HOME/COPR"
 
         run0 sh -c '
-                mv "$result" "$repofilebak" &&\
-                chown "$USER" "$repofilebak" &&\
-                echo 'COPR Repository "$reponame" removed.' ||\
-                echo "ERROR removing COPR repository."
-        '
+        if mv "$1" "$2" && chown "$3" "$2"; then
+            echo "COPR Repository $4 removed."
+        else
+            echo "ERROR: Failed to remove COPR repository."
+        fi
+        ' _ "${repofile:-}" "${repofilebak:-}" "${USER:-}" "${reponame:-}"
 }
 
 # Main loop


### PR DESCRIPTION
fixed unbound variables in copr script by adding empty values if none is provided.
added -p flag to mkdir so that the installation works even if /var/usrlocal/bin already exists.